### PR TITLE
Missing word on home page

### DIFF
--- a/src/talksearch-docgen/layouts/home.pug
+++ b/src/talksearch-docgen/layouts/home.pug
@@ -11,7 +11,7 @@ html(lang="en")
       .spacer40
       .container.text-center.m600
         h2.text-thin.color-white Make it searchable!
-        p.color-portage If your conference or meetup has a YouTube playlist of videos, it can also have a TalkSearch! Algolia will the transcripts from each video and give you back a search page just for your event.
+        p.color-portage If your conference or meetup has a YouTube playlist of videos, it can also have a TalkSearch! Algolia will extract the transcripts from each video and give you back a search page just for your event.
         .spacer80
 
     .fill-athens-gray
@@ -22,7 +22,8 @@ html(lang="en")
             .m400.m-l-r-auto
               h2.text-thin Reach out today
               p.color-portage Conference and meetup organizers are invited to fill out the TalkSearch request form. Algolia will index your videos and email you back a link to your event's unique search experience.
-              p.color-portage Question? Reach us at community@algolia.com.
+              p.color-portage Question? Reach us at 
+                a(href="mailto:community@algolia.com") community@algolia.com.
               .spacer16
               h2.text-thin See it live
               //- img(src="assets/images/devrelcon.png", width=180)


### PR DESCRIPTION
Missing a word in the sentence, and adding a link to the email.