### PR TITLE
docs(header): add href to Vue InstantSearch to the right element

### DIFF
--- a/src/_includes/header.pug
+++ b/src/_includes/header.pug
@@ -30,8 +30,8 @@
             .fln.bg-blue.rounded-auto.w-2x.h-2x
               img.w-100(src="assets/react-icon.svg", alt="React InstantSearch")
             .fla.pl-1.text-solstice.text-2.bold.hover_text-nebula React InstantSearch
-          a.fln.w-50.flex.flrnw.p-05.flc.hover_no-underline
-            .fln.bg-green.rounded-auto.w-2x.h-2x(href="https://community.algolia.com/vue-instantsearch/")
+          a.fln.w-50.flex.flrnw.p-05.flc.hover_no-underline(href="https://community.algolia.com/vue-instantsearch/")
+            .fln.bg-green.rounded-auto.w-2x.h-2x
               img.w-100(src="assets/vue-icon.svg", alt="Vue InstantSearch")
             .fla.pl-1.text-solstice.text-2.bold.hover_text-nebula Vue InstantSearch
           a.fln.w-50.flex.flrnw.p-05.flc.hover_no-underline(href="https://community.algolia.com/angular-instantsearch/")


### PR DESCRIPTION
<!--
Hey there,
Thanks for contributing to TalkSearch!

Note that this repo is for the TalkSearch documentation website. Maybe you're
looking for one of those two other repositories:

- Scraper: https://github.com/algolia/talksearch-scraper
- TalkSearch.js: https://github.com/algolia/talksearch.js

-->

## Why

<!-- 
Let us know why you think this change is necessary. Link to an issue are
appreciated. -->

The href was on the div inside the link, instead of on the link

## How to test

<!-- 
If your PR changes the styling of the website, don't hesitate to share
screenshots of "before/after". -->

try to click on Vue InstantSearch in the header